### PR TITLE
Add checkbox for pre-releases + show non-latest for old installed jasp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,8 @@ on:
 
 # Only have one deployment in progress at a time
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,8 +4,13 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  quality:
+  lint_and_format:
+    name: Lint and Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,3 +21,26 @@ jobs:
           version: latest
       - name: Run Biome
         run: biome ci .
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.18.0'
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Type Check
+        run: pnpm typecheck

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,7 +2,11 @@ name: Code quality
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: '2.2.0'
       - name: Run Biome
         run: biome ci .
   typecheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: 'unit-tests'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pnpm scrape
 pnpm start  
 ```
 
+Application will be running at http://localhost:3000 (unless stated otherwise).
+
 # Building For Production
 
 To build run:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pnpm start
 
 # Building For Production
 
-To build this application for production:
+To build run:
 
 ```bash
 pnpm scrape
@@ -80,10 +80,24 @@ pnpm build
 
 ## Testing
 
-This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:
+We use [Vitest](https://vitest.dev/) for testing. You can run the tests with:
 
 ```bash
 pnpm test
+```
+
+## Linting and Formatting
+
+Can be typechecked with:
+
+```bash
+pnpm typecheck
+```
+
+Can be formatted and linted with:
+
+```bash
+pnpm check
 ```
 
 ## Contributing

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -23,8 +23,15 @@
   },
   "linter": {
     "enabled": true,
+    "domains": {
+      "react": "recommended",
+      "project": "recommended"
+    },
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "nursery": {
+        "useSortedClasses": "error"
+      }
     }
   },
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react-dom": "^19.0.3",
     "@types/semver": "^7.7.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "chalk": "^5.5.0",
     "dedent": "^1.6.0",
     "gray-matter": "^4.0.3",
     "jsdom": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "scripts": {
     "dev": "vite --port 3000",
     "start": "vite --port 3000",
-    "build": "vite build && tsc",
+    "build": "vite build",
     "serve": "vite preview",
     "test": "vitest run",
     "scrape": "node src/scrape.ts",
+    "typecheck": "tsc",
     "check": "biome check --write --unsafe"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.1.4",
+    "@biomejs/biome": "2.2.0",
     "@octokit/core": "^7.0.3",
     "@octokit/graphql": "^9.0.1",
     "@octokit/plugin-paginate-graphql": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         version: 1.1.0(typescript@5.9.2)
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.1.4
-        version: 2.1.4
+        specifier: 2.2.0
+        version: 2.2.0
       '@octokit/core':
         specifier: ^7.0.3
         version: 7.0.3
@@ -248,55 +248,55 @@ packages:
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.1.4':
-    resolution: {integrity: sha512-QWlrqyxsU0FCebuMnkvBIkxvPqH89afiJzjMl+z67ybutse590jgeaFdDurE9XYtzpjRGTI1tlUZPGWmbKsElA==}
+  '@biomejs/biome@2.2.0':
+    resolution: {integrity: sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.1.4':
-    resolution: {integrity: sha512-sCrNENE74I9MV090Wq/9Dg7EhPudx3+5OiSoQOkIe3DLPzFARuL1dOwCWhKCpA3I5RHmbrsbNSRfZwCabwd8Qg==}
+  '@biomejs/cli-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.1.4':
-    resolution: {integrity: sha512-gOEICJbTCy6iruBywBDcG4X5rHMbqCPs3clh3UQ+hRKlgvJTk4NHWQAyHOXvaLe+AxD1/TNX1jbZeffBJzcrOw==}
+  '@biomejs/cli-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.1.4':
-    resolution: {integrity: sha512-nYr7H0CyAJPaLupFE2cH16KZmRC5Z9PEftiA2vWxk+CsFkPZQ6dBRdcC6RuS+zJlPc/JOd8xw3uCCt9Pv41WvQ==}
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
+    resolution: {integrity: sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.1.4':
-    resolution: {integrity: sha512-juhEkdkKR4nbUi5k/KRp1ocGPNWLgFRD4NrHZSveYrD6i98pyvuzmS9yFYgOZa5JhaVqo0HPnci0+YuzSwT2fw==}
+  '@biomejs/cli-linux-arm64@2.2.0':
+    resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.1.4':
-    resolution: {integrity: sha512-lvwvb2SQQHctHUKvBKptR6PLFCM7JfRjpCCrDaTmvB7EeZ5/dQJPhTYBf36BE/B4CRWR2ZiBLRYhK7hhXBCZAg==}
+  '@biomejs/cli-linux-x64-musl@2.2.0':
+    resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.1.4':
-    resolution: {integrity: sha512-Eoy9ycbhpJVYuR+LskV9s3uyaIkp89+qqgqhGQsWnp/I02Uqg2fXFblHJOpGZR8AxdB9ADy87oFVxn9MpFKUrw==}
+  '@biomejs/cli-linux-x64@2.2.0':
+    resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.1.4':
-    resolution: {integrity: sha512-3WRYte7orvyi6TRfIZkDN9Jzoogbv+gSvR+b9VOXUg1We1XrjBg6WljADeVEaKTvOcpVdH0a90TwyOQ6ue4fGw==}
+  '@biomejs/cli-win32-arm64@2.2.0':
+    resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.1.4':
-    resolution: {integrity: sha512-tBc+W7anBPSFXGAoQW+f/+svkpt8/uXfRwDzN1DvnatkRMt16KIYpEi/iw8u9GahJlFv98kgHcIrSsZHZTR0sw==}
+  '@biomejs/cli-win32-x64@2.2.0':
+    resolution: {integrity: sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1907,39 +1907,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@biomejs/biome@2.1.4':
+  '@biomejs/biome@2.2.0':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.1.4
-      '@biomejs/cli-darwin-x64': 2.1.4
-      '@biomejs/cli-linux-arm64': 2.1.4
-      '@biomejs/cli-linux-arm64-musl': 2.1.4
-      '@biomejs/cli-linux-x64': 2.1.4
-      '@biomejs/cli-linux-x64-musl': 2.1.4
-      '@biomejs/cli-win32-arm64': 2.1.4
-      '@biomejs/cli-win32-x64': 2.1.4
+      '@biomejs/cli-darwin-arm64': 2.2.0
+      '@biomejs/cli-darwin-x64': 2.2.0
+      '@biomejs/cli-linux-arm64': 2.2.0
+      '@biomejs/cli-linux-arm64-musl': 2.2.0
+      '@biomejs/cli-linux-x64': 2.2.0
+      '@biomejs/cli-linux-x64-musl': 2.2.0
+      '@biomejs/cli-win32-arm64': 2.2.0
+      '@biomejs/cli-win32-x64': 2.2.0
 
-  '@biomejs/cli-darwin-arm64@2.1.4':
+  '@biomejs/cli-darwin-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.1.4':
+  '@biomejs/cli-darwin-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.1.4':
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.1.4':
+  '@biomejs/cli-linux-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.1.4':
+  '@biomejs/cli-linux-x64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.1.4':
+  '@biomejs/cli-linux-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.1.4':
+  '@biomejs/cli-win32-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.1.4':
+  '@biomejs/cli-win32-x64@2.2.0':
     optional: true
 
   '@csstools/color-helpers@5.0.2': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.3.5(@types/node@24.2.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
+      chalk:
+        specifier: ^5.5.0
+        version: 5.5.0
       dedent:
         specifier: ^1.6.0
         version: 1.6.0
@@ -965,6 +968,10 @@ packages:
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
+
+  chalk@5.5.0:
+    resolution: {integrity: sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -2515,6 +2522,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.0
       pathval: 2.0.1
+
+  chalk@5.5.0: {}
 
   check-error@2.1.1: {}
 

--- a/src/index.json
+++ b/src/index.json
@@ -49,875 +49,1083 @@
       "name": "recapJaspModule",
       "shortDescriptionHTML": "This repo has the required folder structure and some configuration files for a JASP module.",
       "organization": "recap",
-      "latest": [],
-      "preRelease": []
+      "releases": [],
+      "preReleases": []
     },
     "jasp-stats-modules/jaspKinematics": {
       "name": "jaspKinematics",
       "shortDescriptionHTML": "JASP implementation of the kinematics package",
       "organization": "PabRod",
-      "latest": [],
-      "preRelease": []
+      "releases": [],
+      "preReleases": []
     },
     "jasp-stats-modules/jaspAcceptanceSampling": {
       "name": "jaspAcceptanceSampling",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "014ad5af_R-4-5-1",
           "publishedAt": "2025-08-07T21:37:19Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspAcceptanceSampling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspAnova": {
       "name": "jaspAnova",
       "shortDescriptionHTML": "The ANOVA Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "2cbd8a6d_R-4-5-1",
           "publishedAt": "2025-08-07T21:56:13Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "Windows_x86-64"
-            },
-            {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspAudit": {
       "name": "jaspAudit",
       "shortDescriptionHTML": "The Audit module is designed to support statistical auditing using both Bayesian and classical approaches. The module is based on the R package jfa. ",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "0c61b76d_R-4-5-1",
           "publishedAt": "2025-08-07T22:03:28Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspAudit_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspBFF": {
       "name": "jaspBFF",
       "shortDescriptionHTML": "Bayes Factor Functions",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "9ac0b730_R-4-5-1",
           "publishedAt": "2025-08-07T22:05:07Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspBFF_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspBain": {
       "name": "jaspBain",
       "shortDescriptionHTML": "The BAIN Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "f29ac0ad_R-4-5-1",
           "publishedAt": "2025-08-07T22:12:40Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspBain_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspBfpack": {
       "name": "jaspBfpack",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "8ce350ea_R-4-5-1",
           "publishedAt": "2025-08-07T22:20:04Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspBfpack_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspBsts": {
       "name": "jaspBsts",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "c4cda11e_R-4-5-1",
           "publishedAt": "2025-08-07T22:22:22Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspBsts_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspCircular": {
       "name": "jaspCircular",
       "shortDescriptionHTML": "A circular statistics module for JASP",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "cf6367bb_R-4-5-1",
           "publishedAt": "2025-08-07T22:23:53Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspCircular_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspCochrane": {
       "name": "jaspCochrane",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "1cf9c6cb_R-4-5-1",
           "publishedAt": "2025-08-07T22:31:43Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspDescriptives": {
       "name": "jaspDescriptives",
       "shortDescriptionHTML": "The Descriptives Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "6ed8cedb_R-4-5-1",
           "publishedAt": "2025-08-07T22:36:14Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "Windows_x86-64"
-            },
-            {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspDescriptives_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspDistributions": {
       "name": "jaspDistributions",
       "shortDescriptionHTML": "The Discover Distributions Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "52277953_R-4-5-1",
           "publishedAt": "2025-08-07T22:38:53Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspEquivalenceTTests": {
       "name": "jaspEquivalenceTTests",
       "shortDescriptionHTML": "The Equivalence T-Tests Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "7aad95f4_R-4-5-1",
           "publishedAt": "2025-08-07T22:45:03Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspEsci": {
       "name": "jaspEsci",
       "shortDescriptionHTML": "This repo has the required folder structure and some configuration files for a JASP module.",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "3051fc5b_R-4-5-1",
           "publishedAt": "2025-08-07T22:47:39Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspFactor": {
       "name": "jaspFactor",
       "shortDescriptionHTML": "The Factor Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "57729b0c_R-4-5-1",
           "publishedAt": "2025-08-07T22:55:45Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "Windows_x86-64"
-            },
-            {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspFactor_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspFrequencies": {
       "name": "jaspFrequencies",
       "shortDescriptionHTML": "The Frequencies Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "3afc6d37_R-4-5-1",
           "publishedAt": "2025-08-07T22:59:15Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspFrequencies_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspJags": {
       "name": "jaspJags",
       "shortDescriptionHTML": "The JAGS Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "7c2b5e98_R-4-5-1",
           "publishedAt": "2025-08-07T23:01:05Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspLearnBayes": {
       "name": "jaspLearnBayes",
       "shortDescriptionHTML": "A module to help learn bayesian statistics",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "002bc1f0_R-4-5-1",
           "publishedAt": "2025-08-07T23:24:42Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspLearnStats": {
       "name": "jaspLearnStats",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "49c54a16_R-4-5-1",
           "publishedAt": "2025-08-07T23:29:38Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspMachineLearning": {
       "name": "jaspMachineLearning",
       "shortDescriptionHTML": "The Machine Learning Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "74241a1e_R-4-5-1",
           "publishedAt": "2025-08-07T23:33:37Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspMetaAnalysis": {
       "name": "jaspMetaAnalysis",
       "shortDescriptionHTML": "The Meta Analysis Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "f9c16518_R-4-5-1",
           "publishedAt": "2025-08-07T23:42:31Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspMixedModels": {
       "name": "jaspMixedModels",
       "shortDescriptionHTML": "The Mixed Models Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "401d9203_R-4-5-1",
           "publishedAt": "2025-08-07T23:49:58Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspMixedModels_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspNetwork": {
       "name": "jaspNetwork",
       "shortDescriptionHTML": "The Network Analysis Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "d8f265ec_R-4-5-1",
           "publishedAt": "2025-08-07T23:58:29Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspPower": {
       "name": "jaspPower",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "401069f6_R-4-5-1",
           "publishedAt": "2025-08-08T00:00:19Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspPredictiveAnalytics": {
       "name": "jaspPredictiveAnalytics",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "017b5cea_R-4-5-1",
           "publishedAt": "2025-08-08T00:08:18Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspProcess": {
       "name": "jaspProcess",
       "shortDescriptionHTML": "The PROCESS module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "23091130_R-4-5-1",
           "publishedAt": "2025-08-08T00:15:14Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspProphet": {
       "name": "jaspProphet",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "beb9fbae_R-4-5-1",
           "publishedAt": "2025-08-08T00:22:17Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspQualityControl": {
       "name": "jaspQualityControl",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "cb9c6df6_R-4-5-1",
           "publishedAt": "2025-08-08T00:28:08Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspRegression": {
       "name": "jaspRegression",
       "shortDescriptionHTML": "The Regression Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "5649cad6_R-4-5-1",
           "publishedAt": "2025-08-08T00:34:37Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspRegression_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspReliability": {
       "name": "jaspReliability",
       "shortDescriptionHTML": "The Reliability Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "fb0cc6f5_R-4-5-1",
           "publishedAt": "2025-08-08T00:37:56Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspSem": {
       "name": "jaspSem",
       "shortDescriptionHTML": "The SEM Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "b16747cb_R-4-5-1",
           "publishedAt": "2025-08-08T00:46:58Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspSummaryStatistics": {
       "name": "jaspSummaryStatistics",
       "shortDescriptionHTML": "The Summary Statistics Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "d5391a19_R-4-5-1",
           "publishedAt": "2025-08-08T00:53:53Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspSurvival": {
       "name": "jaspSurvival",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "d5d503cf_R-4-5-1",
           "publishedAt": "2025-08-08T00:56:27Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspTTests": {
       "name": "jaspTTests",
       "shortDescriptionHTML": "The T-Tests Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "f5516934_R-4-5-1",
           "publishedAt": "2025-08-08T00:58:58Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": [
+        {
+          "tagName": "f5516934_R-4-5-1-beta1",
+          "publishedAt": "2025-08-09T00:58:58Z",
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            }
+          ]
+        }
+      ]
     },
     "jasp-stats-modules/jaspTestModule": {
       "name": "jaspTestModule",
       "shortDescriptionHTML": "A module to test stuff with",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "f21139e4_R-4-5-1",
           "publishedAt": "2025-08-08T01:00:33Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "Windows_x86-64"
-            },
-            {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
-              "name": "jaspTestModule_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     },
     "jasp-stats-modules/jaspVisualModeling": {
       "name": "jaspVisualModeling",
       "shortDescriptionHTML": "The Visual Modeling Module",
       "organization": "jasp-stats",
-      "latest": [
+      "releases": [
         {
           "tagName": "55d0f2d9_R-4-5-1",
           "publishedAt": "2025-08-08T01:04:55Z",
-          "isPrerelease": false,
           "jaspVersionRange": ">=0.95.1",
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "name": "jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
               "downloadCount": 0,
               "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
             }
           ]
         }
       ],
-      "preRelease": []
+      "preReleases": []
     }
   }
 }

--- a/src/index.json
+++ b/src/index.json
@@ -71,13 +71,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 3,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -102,7 +102,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -111,7 +111,7 @@
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 3,
               "architecture": "Windows_x86-64"
             }
           ]
@@ -124,7 +124,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -153,13 +153,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 2,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -183,13 +183,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 1,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -219,7 +219,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -249,7 +249,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -273,13 +273,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 1,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -303,13 +303,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 2,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             }
           ]
         }
@@ -328,13 +328,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 1,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -359,7 +359,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -394,7 +394,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -424,7 +424,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -454,7 +454,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -479,7 +479,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -514,7 +514,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -544,7 +544,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -574,7 +574,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -604,7 +604,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -634,7 +634,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -664,7 +664,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -688,13 +688,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 1,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -724,7 +724,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -754,7 +754,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -784,7 +784,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -814,7 +814,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -844,7 +844,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -874,7 +874,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -898,13 +898,13 @@
           "assets": [
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 1,
               "architecture": "Windows_x86-64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -934,7 +934,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -964,7 +964,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -994,7 +994,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -1024,7 +1024,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -1054,7 +1054,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -1078,7 +1078,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule",
@@ -1102,7 +1102,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
@@ -1111,7 +1111,7 @@
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-              "downloadCount": 0,
+              "downloadCount": 14,
               "architecture": "Windows_x86-64"
             }
           ]
@@ -1137,7 +1137,7 @@
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
               "downloadCount": 0,
-              "architecture": "x86_64"
+              "architecture": "MacOS_x86_64"
             },
             {
               "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",

--- a/src/index.json
+++ b/src/index.json
@@ -115,6 +115,28 @@
               "architecture": "Windows_x86-64"
             }
           ]
+        },
+        {
+          "tagName": "2cbd8a3e_R-4-4-1",
+          "publishedAt": "2025-05-07T21:56:13Z",
+          "jaspVersionRange": ">=0.94.0",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
         }
       ],
       "preReleases": []

--- a/src/index.json
+++ b/src/index.json
@@ -48,642 +48,876 @@
     "jasp-stats-modules/recapJaspModule": {
       "name": "recapJaspModule",
       "shortDescriptionHTML": "This repo has the required folder structure and some configuration files for a JASP module.",
-      "organization": "recap"
+      "organization": "recap",
+      "latest": [],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspKinematics": {
       "name": "jaspKinematics",
       "shortDescriptionHTML": "JASP implementation of the kinematics package",
-      "organization": "PabRod"
+      "organization": "PabRod",
+      "latest": [],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspAcceptanceSampling": {
       "name": "jaspAcceptanceSampling",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "014ad5af_R-4-5-1",
-        "publishedAt": "2025-08-07T21:37:19Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "014ad5af_R-4-5-1",
+          "publishedAt": "2025-08-07T21:37:19Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspAcceptanceSampling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/014ad5af_R-4-5-1/jaspAcceptanceSampling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspAcceptanceSampling_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspAnova": {
       "name": "jaspAnova",
       "shortDescriptionHTML": "The ANOVA Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "2cbd8a6d_R-4-5-1",
-        "publishedAt": "2025-08-07T21:56:13Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "2cbd8a6d_R-4-5-1",
+          "publishedAt": "2025-08-07T21:56:13Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a6d_R-4-5-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspAudit": {
       "name": "jaspAudit",
       "shortDescriptionHTML": "The Audit module is designed to support statistical auditing using both Bayesian and classical approaches. The module is based on the R package jfa. ",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "0c61b76d_R-4-5-1",
-        "publishedAt": "2025-08-07T22:03:28Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "0c61b76d_R-4-5-1",
+          "publishedAt": "2025-08-07T22:03:28Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspAudit_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspAudit/releases/download/0c61b76d_R-4-5-1/jaspAudit_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspAudit_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspBFF": {
       "name": "jaspBFF",
       "shortDescriptionHTML": "Bayes Factor Functions",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "9ac0b730_R-4-5-1",
-        "publishedAt": "2025-08-07T22:05:07Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "9ac0b730_R-4-5-1",
+          "publishedAt": "2025-08-07T22:05:07Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspBFF_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBFF/releases/download/9ac0b730_R-4-5-1/jaspBFF_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspBFF_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspBain": {
       "name": "jaspBain",
       "shortDescriptionHTML": "The BAIN Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "f29ac0ad_R-4-5-1",
-        "publishedAt": "2025-08-07T22:12:40Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "f29ac0ad_R-4-5-1",
+          "publishedAt": "2025-08-07T22:12:40Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspBain_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBain/releases/download/f29ac0ad_R-4-5-1/jaspBain_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspBain_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspBfpack": {
       "name": "jaspBfpack",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "8ce350ea_R-4-5-1",
-        "publishedAt": "2025-08-07T22:20:04Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "8ce350ea_R-4-5-1",
+          "publishedAt": "2025-08-07T22:20:04Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspBfpack_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBfpack/releases/download/8ce350ea_R-4-5-1/jaspBfpack_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspBfpack_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspBsts": {
       "name": "jaspBsts",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "c4cda11e_R-4-5-1",
-        "publishedAt": "2025-08-07T22:22:22Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "c4cda11e_R-4-5-1",
+          "publishedAt": "2025-08-07T22:22:22Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspBsts_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspBsts/releases/download/c4cda11e_R-4-5-1/jaspBsts_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspBsts_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspCircular": {
       "name": "jaspCircular",
       "shortDescriptionHTML": "A circular statistics module for JASP",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "cf6367bb_R-4-5-1",
-        "publishedAt": "2025-08-07T22:23:53Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "cf6367bb_R-4-5-1",
+          "publishedAt": "2025-08-07T22:23:53Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspCircular_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspCircular/releases/download/cf6367bb_R-4-5-1/jaspCircular_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspCircular_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspCochrane": {
       "name": "jaspCochrane",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "1cf9c6cb_R-4-5-1",
-        "publishedAt": "2025-08-07T22:31:43Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "1cf9c6cb_R-4-5-1",
+          "publishedAt": "2025-08-07T22:31:43Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspCochrane/releases/download/1cf9c6cb_R-4-5-1/jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspCochrane_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspDescriptives": {
       "name": "jaspDescriptives",
       "shortDescriptionHTML": "The Descriptives Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "6ed8cedb_R-4-5-1",
-        "publishedAt": "2025-08-07T22:36:14Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "6ed8cedb_R-4-5-1",
+          "publishedAt": "2025-08-07T22:36:14Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspDescriptives_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDescriptives/releases/download/6ed8cedb_R-4-5-1/jaspDescriptives_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspDescriptives_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspDistributions": {
       "name": "jaspDistributions",
       "shortDescriptionHTML": "The Discover Distributions Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "52277953_R-4-5-1",
-        "publishedAt": "2025-08-07T22:38:53Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "52277953_R-4-5-1",
+          "publishedAt": "2025-08-07T22:38:53Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspDistributions/releases/download/52277953_R-4-5-1/jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspDistributions_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspEquivalenceTTests": {
       "name": "jaspEquivalenceTTests",
       "shortDescriptionHTML": "The Equivalence T-Tests Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "7aad95f4_R-4-5-1",
-        "publishedAt": "2025-08-07T22:45:03Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "7aad95f4_R-4-5-1",
+          "publishedAt": "2025-08-07T22:45:03Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEquivalenceTTests/releases/download/7aad95f4_R-4-5-1/jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspEquivalenceTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspEsci": {
       "name": "jaspEsci",
       "shortDescriptionHTML": "This repo has the required folder structure and some configuration files for a JASP module.",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "3051fc5b_R-4-5-1",
-        "publishedAt": "2025-08-07T22:47:39Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "3051fc5b_R-4-5-1",
+          "publishedAt": "2025-08-07T22:47:39Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspEsci/releases/download/3051fc5b_R-4-5-1/jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspEsci_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspFactor": {
       "name": "jaspFactor",
       "shortDescriptionHTML": "The Factor Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "57729b0c_R-4-5-1",
-        "publishedAt": "2025-08-07T22:55:45Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "57729b0c_R-4-5-1",
+          "publishedAt": "2025-08-07T22:55:45Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspFactor_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFactor/releases/download/57729b0c_R-4-5-1/jaspFactor_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspFactor_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspFrequencies": {
       "name": "jaspFrequencies",
       "shortDescriptionHTML": "The Frequencies Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "3afc6d37_R-4-5-1",
-        "publishedAt": "2025-08-07T22:59:15Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "3afc6d37_R-4-5-1",
+          "publishedAt": "2025-08-07T22:59:15Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspFrequencies_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspFrequencies/releases/download/3afc6d37_R-4-5-1/jaspFrequencies_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspFrequencies_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspJags": {
       "name": "jaspJags",
       "shortDescriptionHTML": "The JAGS Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "7c2b5e98_R-4-5-1",
-        "publishedAt": "2025-08-07T23:01:05Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "7c2b5e98_R-4-5-1",
+          "publishedAt": "2025-08-07T23:01:05Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspJags/releases/download/7c2b5e98_R-4-5-1/jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspJags_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspLearnBayes": {
       "name": "jaspLearnBayes",
       "shortDescriptionHTML": "A module to help learn bayesian statistics",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "002bc1f0_R-4-5-1",
-        "publishedAt": "2025-08-07T23:24:42Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "002bc1f0_R-4-5-1",
+          "publishedAt": "2025-08-07T23:24:42Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnBayes/releases/download/002bc1f0_R-4-5-1/jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspLearnBayes_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspLearnStats": {
       "name": "jaspLearnStats",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "49c54a16_R-4-5-1",
-        "publishedAt": "2025-08-07T23:29:38Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "49c54a16_R-4-5-1",
+          "publishedAt": "2025-08-07T23:29:38Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspLearnStats/releases/download/49c54a16_R-4-5-1/jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspLearnStats_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspMachineLearning": {
       "name": "jaspMachineLearning",
       "shortDescriptionHTML": "The Machine Learning Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "74241a1e_R-4-5-1",
-        "publishedAt": "2025-08-07T23:33:37Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "74241a1e_R-4-5-1",
+          "publishedAt": "2025-08-07T23:33:37Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMachineLearning/releases/download/74241a1e_R-4-5-1/jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspMachineLearning_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspMetaAnalysis": {
       "name": "jaspMetaAnalysis",
       "shortDescriptionHTML": "The Meta Analysis Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "f9c16518_R-4-5-1",
-        "publishedAt": "2025-08-07T23:42:31Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "f9c16518_R-4-5-1",
+          "publishedAt": "2025-08-07T23:42:31Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMetaAnalysis/releases/download/f9c16518_R-4-5-1/jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspMetaAnalysis_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspMixedModels": {
       "name": "jaspMixedModels",
       "shortDescriptionHTML": "The Mixed Models Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "401d9203_R-4-5-1",
-        "publishedAt": "2025-08-07T23:49:58Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "401d9203_R-4-5-1",
+          "publishedAt": "2025-08-07T23:49:58Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspMixedModels_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspMixedModels/releases/download/401d9203_R-4-5-1/jaspMixedModels_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspMixedModels_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspNetwork": {
       "name": "jaspNetwork",
       "shortDescriptionHTML": "The Network Analysis Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "d8f265ec_R-4-5-1",
-        "publishedAt": "2025-08-07T23:58:29Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "d8f265ec_R-4-5-1",
+          "publishedAt": "2025-08-07T23:58:29Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspNetwork/releases/download/d8f265ec_R-4-5-1/jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspNetwork_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspPower": {
       "name": "jaspPower",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "401069f6_R-4-5-1",
-        "publishedAt": "2025-08-08T00:00:19Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "401069f6_R-4-5-1",
+          "publishedAt": "2025-08-08T00:00:19Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPower/releases/download/401069f6_R-4-5-1/jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspPower_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspPredictiveAnalytics": {
       "name": "jaspPredictiveAnalytics",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "017b5cea_R-4-5-1",
-        "publishedAt": "2025-08-08T00:08:18Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "017b5cea_R-4-5-1",
+          "publishedAt": "2025-08-08T00:08:18Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspPredictiveAnalytics/releases/download/017b5cea_R-4-5-1/jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspPredictiveAnalytics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspProcess": {
       "name": "jaspProcess",
       "shortDescriptionHTML": "The PROCESS module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "23091130_R-4-5-1",
-        "publishedAt": "2025-08-08T00:15:14Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "23091130_R-4-5-1",
+          "publishedAt": "2025-08-08T00:15:14Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProcess/releases/download/23091130_R-4-5-1/jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspProcess_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspProphet": {
       "name": "jaspProphet",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "beb9fbae_R-4-5-1",
-        "publishedAt": "2025-08-08T00:22:17Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "beb9fbae_R-4-5-1",
+          "publishedAt": "2025-08-08T00:22:17Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspProphet/releases/download/beb9fbae_R-4-5-1/jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspProphet_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspQualityControl": {
       "name": "jaspQualityControl",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "cb9c6df6_R-4-5-1",
-        "publishedAt": "2025-08-08T00:28:08Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "cb9c6df6_R-4-5-1",
+          "publishedAt": "2025-08-08T00:28:08Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspQualityControl/releases/download/cb9c6df6_R-4-5-1/jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspQualityControl_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspRegression": {
       "name": "jaspRegression",
       "shortDescriptionHTML": "The Regression Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "5649cad6_R-4-5-1",
-        "publishedAt": "2025-08-08T00:34:37Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "5649cad6_R-4-5-1",
+          "publishedAt": "2025-08-08T00:34:37Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspRegression_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspRegression/releases/download/5649cad6_R-4-5-1/jaspRegression_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspRegression_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspReliability": {
       "name": "jaspReliability",
       "shortDescriptionHTML": "The Reliability Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "fb0cc6f5_R-4-5-1",
-        "publishedAt": "2025-08-08T00:37:56Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "fb0cc6f5_R-4-5-1",
+          "publishedAt": "2025-08-08T00:37:56Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspReliability/releases/download/fb0cc6f5_R-4-5-1/jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspReliability_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspSem": {
       "name": "jaspSem",
       "shortDescriptionHTML": "The SEM Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "b16747cb_R-4-5-1",
-        "publishedAt": "2025-08-08T00:46:58Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "b16747cb_R-4-5-1",
+          "publishedAt": "2025-08-08T00:46:58Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSem/releases/download/b16747cb_R-4-5-1/jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspSem_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspSummaryStatistics": {
       "name": "jaspSummaryStatistics",
       "shortDescriptionHTML": "The Summary Statistics Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "d5391a19_R-4-5-1",
-        "publishedAt": "2025-08-08T00:53:53Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "d5391a19_R-4-5-1",
+          "publishedAt": "2025-08-08T00:53:53Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSummaryStatistics/releases/download/d5391a19_R-4-5-1/jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspSummaryStatistics_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspSurvival": {
       "name": "jaspSurvival",
       "shortDescriptionHTML": "",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "d5d503cf_R-4-5-1",
-        "publishedAt": "2025-08-08T00:56:27Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "d5d503cf_R-4-5-1",
+          "publishedAt": "2025-08-08T00:56:27Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspSurvival/releases/download/d5d503cf_R-4-5-1/jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspSurvival_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspTTests": {
       "name": "jaspTTests",
       "shortDescriptionHTML": "The T-Tests Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "f5516934_R-4-5-1",
-        "publishedAt": "2025-08-08T00:58:58Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "f5516934_R-4-5-1",
+          "publishedAt": "2025-08-08T00:58:58Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspTTests_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspTestModule": {
       "name": "jaspTestModule",
       "shortDescriptionHTML": "A module to test stuff with",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "f21139e4_R-4-5-1",
-        "publishedAt": "2025-08-08T01:00:33Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "f21139e4_R-4-5-1",
+          "publishedAt": "2025-08-08T01:00:33Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspTestModule_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTestModule/releases/download/f21139e4_R-4-5-1/jaspTestModule_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "name": "jaspTestModule_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     },
     "jasp-stats-modules/jaspVisualModeling": {
       "name": "jaspVisualModeling",
       "shortDescriptionHTML": "The Visual Modeling Module",
       "organization": "jasp-stats",
-      "latestRelease": {
-        "tagName": "55d0f2d9_R-4-5-1",
-        "publishedAt": "2025-08-08T01:04:55Z",
-        "jaspVersionRange": ">=0.95.1",
-        "assets": [
-          {
-            "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "name": "jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
-            "downloadCount": 0,
-            "architecture": "Windows_x86-64"
-          }
-        ]
-      }
+      "latest": [
+        {
+          "tagName": "55d0f2d9_R-4-5-1",
+          "publishedAt": "2025-08-08T01:04:55Z",
+          "isPrerelease": false,
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspVisualModeling/releases/download/55d0f2d9_R-4-5-1/jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "name": "jaspVisualModeling_0.95.0_Windows_x86-64_R-4-5-1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            }
+          ]
+        }
+      ],
+      "preRelease": []
     }
   }
 }

--- a/src/index.json
+++ b/src/index.json
@@ -45,20 +45,6 @@
     ]
   },
   "assets": {
-    "jasp-stats-modules/recapJaspModule": {
-      "name": "recapJaspModule",
-      "shortDescriptionHTML": "This repo has the required folder structure and some configuration files for a JASP module.",
-      "organization": "recap",
-      "releases": [],
-      "preReleases": []
-    },
-    "jasp-stats-modules/jaspKinematics": {
-      "name": "jaspKinematics",
-      "shortDescriptionHTML": "JASP implementation of the kinematics package",
-      "organization": "PabRod",
-      "releases": [],
-      "preReleases": []
-    },
     "jasp-stats-modules/jaspAcceptanceSampling": {
       "name": "jaspAcceptanceSampling",
       "shortDescriptionHTML": "",

--- a/src/index.json
+++ b/src/index.json
@@ -486,7 +486,8 @@
       "name": "jaspFrequencies",
       "shortDescriptionHTML": "The Frequencies Module",
       "organization": "jasp-stats",
-      "releases": [
+      "releases": [],
+      "preReleases": [
         {
           "tagName": "3afc6d37_R-4-5-1",
           "publishedAt": "2025-08-07T22:59:15Z",
@@ -509,8 +510,7 @@
             }
           ]
         }
-      ],
-      "preReleases": []
+      ]
     },
     "jasp-stats-modules/jaspJags": {
       "name": "jaspJags",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -53,7 +53,7 @@ function InstallButton({ asset }: { asset?: ReleaseAsset }) {
   return (
     <a
       href={asset.downloadUrl}
-      className="inline-flex items-center px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-medium rounded transition-colors duration-200"
+      className="inline-flex items-center rounded bg-green-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-green-700"
     >
       Install
     </a>
@@ -67,7 +67,7 @@ function UpdateButton({ asset }: { asset?: ReleaseAsset }) {
   return (
     <a
       href={asset.downloadUrl}
-      className="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded transition-colors duration-200"
+      className="inline-flex items-center rounded bg-blue-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-blue-700"
     >
       Update
     </a>
@@ -116,20 +116,20 @@ function RepositoryCard({
   // For now assume installed version can be updated
   const canUpdate = installedVersion && !latestVersionInstalled;
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3 hover:shadow-md transition-shadow duration-200">
-      <div className="flex justify-between items-start gap-2 mb-2">
-        <h3 className="text-lg font-semibold text-gray-900">{repo.name}</h3>
+    <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-shadow duration-200 hover:shadow-md">
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <h3 className="font-semibold text-gray-900 text-lg">{repo.name}</h3>
         <div className="flex-shrink-0">
           <div className="flex flex-col">
             {canUpdate && <UpdateButton asset={archAsset} />}
             {canInstall && !canUpdate && <InstallButton asset={archAsset} />}
             {allowPreRelease && latestPreRelease && (
-              <span className="text-xs text-gray-500">Pre release</span>
+              <span className="text-gray-500 text-xs">Pre release</span>
             )}
             {latestVersionInstalled && (
               <span
                 title="Latest version is installed"
-                className="text-xs text-gray-500"
+                className="text-gray-500 text-xs"
               >
                 Installed
               </span>
@@ -139,13 +139,13 @@ function RepositoryCard({
       </div>
       <div className="flex flex-col gap-2">
         {repo.shortDescriptionHTML && (
-          <div className="text-gray-600 text-sm mb-2 prose prose-sm">
+          <div className="prose prose-sm mb-2 text-gray-600 text-sm">
             {repo.shortDescriptionHTML}
           </div>
         )}
         {latestAnyRelease && (
-          <div className="flex flex-row gap-1 text-xs text-gray-500">
-            <span className="inline-flex items-center w-fit">
+          <div className="flex flex-row gap-1 text-gray-500 text-xs">
+            <span className="inline-flex w-fit items-center">
               {installedVersion
                 ? ` installed: ${installedVersion}, latest`
                 : 'latest '}{' '}
@@ -210,16 +210,16 @@ function App() {
   return (
     <main className="min-h-screen bg-gray-50 py-4">
       <div className="w-full px-2">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3 mb-4">
+        <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
           <form className="flex flex-col gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-700 mb-1">
+              <label className="mb-1 block font-medium text-gray-700 text-xs">
                 Select a channel:
                 <select
                   name="channel"
                   value={channel}
                   onChange={(e) => setChannel(e.target.value)}
-                  className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white"
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
                 >
                   {channels.map((channel) => (
                     <option key={channel} value={channel}>
@@ -230,25 +230,25 @@ function App() {
               </label>
             </div>
             <div>
-              <label className="text-xs font-medium text-gray-700 mb-1 flex items-center">
+              <label className="mb-1 flex items-center font-medium text-gray-700 text-xs">
                 Allow pre-releases
                 <input
                   type="checkbox"
                   name="allowPreReleases"
-                  className="ml-2 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 focus:ring-2"
+                  className="ml-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
                   checked={allowPreRelease}
                   onChange={(e) => setAllowPreRelease(e.target.checked)}
                 />
               </label>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-700 mb-1">
+              <label className="mb-1 block font-medium text-gray-700 text-xs">
                 Search for a module:
                 <input
                   type="search"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
                 />
               </label>
             </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -153,8 +153,8 @@ function RepositoryCard({
                 : 'latest '}{' '}
               {latestAnyRelease.tagName.replace('v', '')} on{' '}
               {new Date(latestAnyRelease.publishedAt).toLocaleDateString()}
-            </span>
-            <span>by {repo.organization}</span>
+            </span>{' '}
+            <span>by {repo.organization}</span>{' '}
             <span>with {archAsset?.downloadCount} downloads</span>
           </div>
         )}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -89,7 +89,7 @@ function RepositoryCard({ repo }: { repo: Repository }) {
     v: installedJaspVersion,
   } = Route.useSearch();
   const latestRelease = findReleaseThatSatisfiesInstalledJaspVersion(
-    repo.latest,
+    repo.releases,
     installedJaspVersion,
   );
   const archAsset = latestRelease?.assets.find((a) => a.architecture === arch);
@@ -151,7 +151,7 @@ function App() {
     .map(([_, repo]) => repo);
   const installableRepos = reposOfChannel.filter((repo) => {
     const latestRelease = findReleaseThatSatisfiesInstalledJaspVersion(
-      repo.latest,
+      repo.releases,
       installedJaspVersion,
     );
     if (!latestRelease) {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -109,7 +109,9 @@ function RepositoryCard({
     (a) => a.architecture === arch,
   );
   const installedVersion = installedModules[repo.name];
-  const latestVersionInstalled = installedVersion === latestAnyRelease?.tagName;
+  const latestVersionInstalled =
+    installedVersion !== undefined &&
+    installedVersion === latestAnyRelease?.tagName;
   const canInstall = !installedVersion || !latestVersionInstalled;
   // tagName (d5d503cf_R-4-5-1) is not a semantic version, so we cannot
   // tell if it can be updated or downgraded
@@ -173,13 +175,19 @@ function App() {
     .filter(([repo, _]) => channels2repos[channel].includes(repo))
     .map(([_, repo]) => repo);
   const installableRepos = reposOfChannel.filter((repo) => {
-    const latestRelease = findReleaseThatSatisfiesInstalledJaspVersion(
+    let latestRelease = findReleaseThatSatisfiesInstalledJaspVersion(
       repo.releases,
       installedJaspVersion,
     );
     if (!latestRelease) {
-      // No compatible release found
-      return false;
+      // No compatible release found, trying pre-release
+      latestRelease = findReleaseThatSatisfiesInstalledJaspVersion(
+        repo.preReleases,
+        installedJaspVersion,
+      );
+      if (!allowPreRelease || !latestRelease) {
+        return false;
+      }
     }
     const hasArch = latestRelease.assets.some(
       (a) => a.architecture === architecture,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -240,8 +240,8 @@ function App() {
                     className="ml-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
                     checked={allowPreRelease}
                     onChange={(e) => setAllowPreRelease(e.target.checked)}
-                    />
-                    <span className="ml-2">Show pre-releases</span>
+                  />
+                  <span className="ml-2">Show pre-releases</span>
                 </label>
               </div>
             </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -118,7 +118,14 @@ function RepositoryCard({
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-shadow duration-200 hover:shadow-md">
       <div className="mb-2 flex items-start justify-between gap-2">
-        <h3 className="font-semibold text-gray-900 text-lg">{repo.name}</h3>
+        <div>
+          <h3 className="font-semibold text-gray-900 text-lg">{repo.name}</h3>
+          {repo.shortDescriptionHTML && (
+            <div className="prose prose-sm mb-2 text-gray-600 text-sm">
+              {repo.shortDescriptionHTML}
+            </div>
+          )}
+        </div>
         <div className="flex-shrink-0">
           <div className="flex flex-col">
             {canUpdate && <UpdateButton asset={archAsset} />}
@@ -129,7 +136,7 @@ function RepositoryCard({
             {latestVersionInstalled && (
               <span
                 title="Latest version is installed"
-                className="text-gray-500 text-xs"
+                className="px-2 py-1.5 text-gray-500 text-xs"
               >
                 Installed
               </span>
@@ -137,15 +144,10 @@ function RepositoryCard({
           </div>
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        {repo.shortDescriptionHTML && (
-          <div className="prose prose-sm mb-2 text-gray-600 text-sm">
-            {repo.shortDescriptionHTML}
-          </div>
-        )}
+      <div>
         {latestAnyRelease && (
-          <div className="flex flex-row gap-1 text-gray-500 text-xs">
-            <span className="inline-flex w-fit items-center">
+          <div className="text-gray-500 text-xs">
+            <span>
               {installedVersion
                 ? ` installed: ${installedVersion}, latest`
                 : 'latest '}{' '}
@@ -211,35 +213,37 @@ function App() {
     <main className="min-h-screen bg-gray-50 py-4">
       <div className="w-full px-2">
         <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-          <form className="flex flex-col gap-3">
-            <div>
-              <label className="mb-1 block font-medium text-gray-700 text-xs">
-                Select a channel:
-                <select
-                  name="channel"
-                  value={channel}
-                  onChange={(e) => setChannel(e.target.value)}
-                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-                >
-                  {channels.map((channel) => (
-                    <option key={channel} value={channel}>
-                      {channel}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
-            <div>
-              <label className="mb-1 flex items-center font-medium text-gray-700 text-xs">
-                Allow pre-releases
-                <input
-                  type="checkbox"
-                  name="allowPreReleases"
-                  className="ml-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
-                  checked={allowPreRelease}
-                  onChange={(e) => setAllowPreRelease(e.target.checked)}
-                />
-              </label>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-row gap-3">
+              <div>
+                <label className="mb-1 block font-medium text-gray-700 text-xs">
+                  Select a channel:
+                  <select
+                    name="channel"
+                    value={channel}
+                    onChange={(e) => setChannel(e.target.value)}
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  >
+                    {channels.map((channel) => (
+                      <option key={channel} value={channel}>
+                        {channel}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <div className="flex items-center">
+                <label className="mb-1 flex font-medium text-gray-700 text-xs">
+                  <input
+                    type="checkbox"
+                    name="allowPreReleases"
+                    className="ml-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
+                    checked={allowPreRelease}
+                    onChange={(e) => setAllowPreRelease(e.target.checked)}
+                    />
+                    <span className="ml-2">Show pre-releases</span>
+                </label>
+              </div>
             </div>
             <div>
               <label className="mb-1 block font-medium text-gray-700 text-xs">
@@ -252,7 +256,7 @@ function App() {
                 />
               </label>
             </div>
-          </form>
+          </div>
         </div>
 
         <div className="space-y-3">

--- a/src/scrape.test.ts
+++ b/src/scrape.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { jaspVersionRangeFromDescription } from './scrape';
+import {
+  type GqlRelease,
+  jaspVersionRangeFromDescription,
+  latestReleasePerJaspVersionRange,
+} from './scrape';
 
 describe('jaspVersionRangeFromDescription', () => {
   test('singleqouted', () => {
@@ -21,5 +25,55 @@ describe('jaspVersionRangeFromDescription', () => {
 
     const result = jaspVersionRangeFromDescription(description);
     expect(result).toBe('>=0.95.1');
+  });
+});
+
+describe('latestReleasePerJaspVersionRange', () => {
+  test('2 version ranges with each 2 releases', () => {
+    const input: GqlRelease[] = [
+      {
+        // this one should be shown when installed jasp is 0.95.1
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: '<date>',
+        releaseAssets: { nodes: [] },
+        tagName: 'v1.1.1',
+        description: '---\njasp: >=0.95.1\n---\n',
+      },
+      {
+        // Drop superseeded be above
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: '<date>',
+        releaseAssets: { nodes: [] },
+        tagName: 'v1.1.0',
+        description: '---\njasp: >=0.95.1\n---\n',
+      },
+      // versions below do not work in 0.95.1
+      {
+        // should be shown if installed jasp is 0.95.0
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: '<date>',
+        releaseAssets: { nodes: [] },
+        tagName: 'v1.0.1',
+        description: '---\njasp: >=0.95.0\n---\n',
+      },
+      {
+        // Drop superseeded be above
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: '<date>',
+        releaseAssets: { nodes: [] },
+        tagName: 'v1.0.0',
+        description: '---\njasp: >=0.95.0\n---\n',
+      },
+    ];
+
+    const result = latestReleasePerJaspVersionRange(input);
+
+    const expected = [input[0], input[2]];
+
+    expect(result).toEqual(expected);
   });
 });

--- a/src/scrape.test.ts
+++ b/src/scrape.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  extractArchitectureFromUrl,
   type GqlRelease,
   jaspVersionRangeFromDescription,
   latestReleasePerJaspVersionRange,
@@ -75,5 +76,16 @@ describe('latestReleasePerJaspVersionRange', () => {
     const expected = [input[0], input[2]];
 
     expect(result).toEqual(expected);
+  });
+});
+
+describe('extractArchitectureFromUrl', () => {
+  test.each([
+    ['jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule', 'MacOS_x86_64'],
+    ['jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule', 'MacOS_arm64'],
+    ['jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule', 'Windows_x86-64'],
+  ])('extracts architecture from %s', (url, expected) => {
+    const result = extractArchitectureFromUrl(url);
+    expect(result).toBe(expected);
   });
 });

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -177,27 +177,30 @@ async function releaseAssetsPaged(
   // TODO remove once a pre release is on GitHub
   // For now we insert a dummy pre-release
   results['jasp-stats-modules/jaspTTests'].preReleases.push({
-    "tagName": "f5516934_R-4-5-1-beta1",
-          "publishedAt": "2025-08-09T00:58:58Z",
-          "jaspVersionRange": ">=0.95.1",
-          "assets": [
-            {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1-beta1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "Windows_x86-64"
-            },
-            {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "x86_64"
-            },
-            {
-              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule",
-              "downloadCount": 0,
-              "architecture": "MacOS_arm64"
-            }
-          ]
-  })
+    tagName: 'f5516934_R-4-5-1-beta1',
+    publishedAt: '2025-08-09T00:58:58Z',
+    jaspVersionRange: '>=0.95.1',
+    assets: [
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1-beta1.JASPModule',
+        downloadCount: 0,
+        architecture: 'Windows_x86-64',
+      },
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule',
+        downloadCount: 0,
+        architecture: 'x86_64',
+      },
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule',
+        downloadCount: 0,
+        architecture: 'MacOS_arm64',
+      },
+    ],
+  });
 
   return results;
 }
@@ -264,7 +267,13 @@ export function latestReleasePerJaspVersionRange(
 }
 
 function transformRelease(release: GqlRelease, nameWithOwner: string): Release {
-  const { releaseAssets, description, isDraft: _, isPrerelease: __, ...restRelease } = release;
+  const {
+    releaseAssets,
+    description,
+    isDraft: _,
+    isPrerelease: __,
+    ...restRelease
+  } = release;
   let jaspVersionRange = jaspVersionRangeFromDescription(description ?? '');
   if (!jaspVersionRange) {
     jaspVersionRange = '>=0.95.0';

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -173,6 +173,32 @@ async function releaseAssetsPaged(
     const batchResults = await releaseAssets(batch, firstAssets);
     Object.assign(results, batchResults);
   }
+
+  // TODO remove once a pre release is on GitHub
+  // For now we insert a dummy pre-release
+  results['jasp-stats-modules/jaspTTests'].preReleases.push({
+    "tagName": "f5516934_R-4-5-1-beta1",
+          "publishedAt": "2025-08-09T00:58:58Z",
+          "jaspVersionRange": ">=0.95.1",
+          "assets": [
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "Windows_x86-64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "x86_64"
+            },
+            {
+              "downloadUrl": "https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule",
+              "downloadCount": 0,
+              "architecture": "MacOS_arm64"
+            }
+          ]
+  })
+
   return results;
 }
 
@@ -238,7 +264,7 @@ export function latestReleasePerJaspVersionRange(
 }
 
 function transformRelease(release: GqlRelease, nameWithOwner: string): Release {
-  const { releaseAssets, description, isDraft: _, ...restRelease } = release;
+  const { releaseAssets, description, isDraft: _, isPrerelease: __, ...restRelease } = release;
   let jaspVersionRange = jaspVersionRangeFromDescription(description ?? '');
   if (!jaspVersionRange) {
     jaspVersionRange = '>=0.95.0';
@@ -290,7 +316,6 @@ async function releaseAssets(
               releaseAssets(first: ${firstAssets}) {
                 nodes {
                   downloadUrl
-                  name
                   downloadCount
                 }
               }
@@ -305,7 +330,6 @@ async function releaseAssets(
 
   const result = await octokit.graphql<GqlAssetsResult>(fullQuery);
 
-  // Replace repo{i] with the actual nameWithOwner}
   const repositories = Object.fromEntries(
     Object.values(result).map((repo) => {
       const { nameWithOwner, parent: _, releases, ...restRepo } = repo;

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -172,35 +172,6 @@ async function releaseAssetsPaged(
     Object.assign(results, batchResults);
   }
 
-  // TODO remove once a pre release is on GitHub
-  console.log('Inserting dummy pre-release for jaspTTests');
-  // For now we insert a dummy pre-release
-  results['jasp-stats-modules/jaspTTests'].preReleases.push({
-    tagName: 'f5516934_R-4-5-1-beta1',
-    publishedAt: '2025-08-09T00:58:58Z',
-    jaspVersionRange: '>=0.95.1',
-    assets: [
-      {
-        downloadUrl:
-          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_Windows_x86-64_R-4-5-1-beta1.JASPModule',
-        downloadCount: 0,
-        architecture: 'Windows_x86-64',
-      },
-      {
-        downloadUrl:
-          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_x86_64_R-4-5-1-beta1.JASPModule',
-        downloadCount: 0,
-        architecture: 'MacOS_x86_64',
-      },
-      {
-        downloadUrl:
-          'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule',
-        downloadCount: 0,
-        architecture: 'MacOS_arm64',
-      },
-    ],
-  });
-
   // TODO remove once a release is on GitHub that does not work on installed JASP version
   console.log('Inserting dummy old release for jaspAnova');
   // For now we insert a dummy release,

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -175,6 +175,7 @@ async function releaseAssetsPaged(
   }
 
   // TODO remove once a pre release is on GitHub
+  console.log('Inserting dummy pre-release for jaspTTests');
   // For now we insert a dummy pre-release
   results['jasp-stats-modules/jaspTTests'].preReleases.push({
     tagName: 'f5516934_R-4-5-1-beta1',
@@ -198,6 +199,36 @@ async function releaseAssetsPaged(
           'https://github.com/jasp-stats-modules/jaspTTests/releases/download/f5516934_R-4-5-1-beta1/jaspTTests_0.95.0_MacOS_arm64_R-4-5-1-beta1.JASPModule',
         downloadCount: 0,
         architecture: 'MacOS_arm64',
+      },
+    ],
+  });
+
+  // TODO remove once a release is on GitHub that does not work on installed JASP version
+  console.log('Inserting dummy old release for jaspAnova');
+  // For now we insert a dummy release,
+  // try out with ?v=0.95.0 should show release below and not one with R-4-5-1
+  results['jasp-stats-modules/jaspAnova'].releases.push({
+    tagName: '2cbd8a3e_R-4-4-1',
+    publishedAt: '2025-05-07T21:56:13Z',
+    jaspVersionRange: '>=0.94.0',
+    assets: [
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_x86_64_R-4-5-1.JASPModule',
+        downloadCount: 0,
+        architecture: 'x86_64',
+      },
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_MacOS_arm64_R-4-5-1.JASPModule',
+        downloadCount: 0,
+        architecture: 'MacOS_arm64',
+      },
+      {
+        downloadUrl:
+          'https://github.com/jasp-stats-modules/jaspAnova/releases/download/2cbd8a3e_R-4-4-1/jaspAnova_0.95.0_Windows_x86-64_R-4-5-1.JASPModule',
+        downloadCount: 0,
+        architecture: 'Windows_x86-64',
       },
     ],
   });

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -238,7 +238,7 @@ export function latestReleasePerJaspVersionRange(
 }
 
 function transformRelease(release: GqlRelease, nameWithOwner: string): Release {
-  const { releaseAssets, description, isDraft, ...restRelease } = release;
+  const { releaseAssets, description, isDraft: _, ...restRelease } = release;
   let jaspVersionRange = jaspVersionRangeFromDescription(description ?? '');
   if (!jaspVersionRange) {
     jaspVersionRange = '>=0.95.0';
@@ -308,7 +308,7 @@ async function releaseAssets(
   // Replace repo{i] with the actual nameWithOwner}
   const repositories = Object.fromEntries(
     Object.values(result).map((repo) => {
-      const { nameWithOwner, parent, releases, ...restRepo } = repo;
+      const { nameWithOwner, parent: _, releases, ...restRepo } = repo;
       const productionReleases = releases.nodes.filter(
         (r) => !r.isDraft && !r.isPrerelease,
       );
@@ -318,12 +318,12 @@ async function releaseAssets(
       const newRepo: Repository = {
         ...restRepo,
         organization: repo.parent?.owner.login ?? 'unknown_org',
-        latest: latestReleasePerJaspVersionRange(productionReleases).map(
+        releases: latestReleasePerJaspVersionRange(productionReleases).map(
           (r) => {
             return transformRelease(r, nameWithOwner);
           },
         ),
-        preRelease: latestReleasePerJaspVersionRange(preReleases).map((r) => {
+        preReleases: latestReleasePerJaspVersionRange(preReleases).map((r) => {
           return transformRelease(r, nameWithOwner);
         }),
       };

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 body {
+  /* biome-ignore lint/suspicious/noUnknownAtRules: tailwind plugin */
   @apply m-0;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,9 @@ export interface Release {
 export interface Repository {
   name: string;
   shortDescriptionHTML: string;
-  latestRelease?: Release;
+  // each jaspVersionRange can have own latest release
+  latest: Release[];
+  preRelease: Release[];
   organization: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,8 @@ export interface Repository {
   name: string;
   shortDescriptionHTML: string;
   // each jaspVersionRange can have own latest release
-  latest: Release[];
-  preRelease: Release[];
+  releases: Release[];
+  preReleases: Release[];
   organization: string;
 }
 


### PR DESCRIPTION
Refs #5
Refs #8

## Without pre releases (default)
<img width="644" height="241" alt="localhost_3000_ (11)" src="https://github.com/user-attachments/assets/cc6485b2-58e9-43b4-be15-33c7fa3ae8d7" />

## With pre releases
<img width="642" height="261" alt="localhost_3000_ (10)" src="https://github.com/user-attachments/assets/a520b3d3-d649-4439-a1c5-2b8f1b3c7a74" />

## Old installed JASP version

Test by going to 
http://localhost:3000/#/?a=Windows_x86-64&v=0.94.1
Note `v=0.94.1`, will show modules compatible with that version and only Anova has a dummy release that satisfies.

<img width="512" height="129" alt="localhost_3000_ (12)" src="https://github.com/user-attachments/assets/e05587d6-587b-450e-8eeb-130c55500c74" />

Note R-4-4-1 in screenshot, is different from latest R-4-5-1.

# To review

For reviewers to test web application you can follow the instructions  at https://github.com/jasp-stats-modules/modules-app/tree/pre-releases?tab=readme-ov-file#getting-started

Things to test
1. frequencies module in core channel has pre-release, check if you can see it when checkbox is ticked and does not when unchecked.
2. Anova module has a dummy release that works for an old JASP version, check that it shows up with `?v0.94.1` in url and does not by default.
