### PR TITLE
Add dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f9fafb" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
     <meta
       name="description"
       content="Web site created using create-tsrouter-app"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -55,7 +55,7 @@ function InstallButton({ asset }: { asset?: ReleaseAsset }) {
   return (
     <a
       href={asset.downloadUrl}
-      className="inline-flex items-center rounded bg-green-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-green-700"
+      className="inline-flex items-center rounded bg-green-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800"
     >
       Install
     </a>
@@ -69,7 +69,7 @@ function UpdateButton({ asset }: { asset?: ReleaseAsset }) {
   return (
     <a
       href={asset.downloadUrl}
-      className="inline-flex items-center rounded bg-blue-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-blue-700"
+      className="inline-flex items-center rounded bg-blue-600 px-3 py-1.5 font-medium text-white text-xs transition-colors duration-200 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800"
     >
       Update
     </a>
@@ -120,12 +120,14 @@ function RepositoryCard({
   // For now assume installed version can be updated
   const canUpdate = installedVersion && !latestVersionInstalled;
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-shadow duration-200 hover:shadow-md">
+    <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-shadow duration-200 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-lg">
       <div className="mb-2 flex items-start justify-between gap-2">
         <div>
-          <h3 className="font-semibold text-gray-900 text-lg">{repo.name}</h3>
+          <h3 className="font-semibold text-gray-900 text-lg dark:text-gray-100">
+            {repo.name}
+          </h3>
           {repo.shortDescriptionHTML && (
-            <div className="prose prose-sm mb-2 text-gray-600 text-sm">
+            <div className="prose prose-sm mb-2 text-gray-600 text-sm dark:text-gray-300">
               {repo.shortDescriptionHTML}
             </div>
           )}
@@ -135,12 +137,14 @@ function RepositoryCard({
             {canUpdate && <UpdateButton asset={archAsset} />}
             {canInstall && !canUpdate && <InstallButton asset={archAsset} />}
             {allowPreRelease && latestPreRelease && (
-              <span className="text-gray-500 text-xs">Pre release</span>
+              <span className="text-gray-500 text-xs dark:text-gray-400">
+                Pre release
+              </span>
             )}
             {latestVersionInstalled && (
               <span
                 title="Latest version is installed"
-                className="px-2 py-1.5 text-gray-500 text-xs"
+                className="px-2 py-1.5 text-gray-500 text-xs dark:text-gray-400"
               >
                 Installed
               </span>
@@ -150,7 +154,7 @@ function RepositoryCard({
       </div>
       <div>
         {latestAnyRelease && (
-          <div className="text-gray-500 text-xs">
+          <div className="text-gray-500 text-xs dark:text-gray-400">
             <span>
               {installedVersion
                 ? ` installed: ${installedVersion}, latest`
@@ -226,19 +230,19 @@ function App() {
   });
 
   return (
-    <main className="min-h-screen bg-gray-50 py-4">
+    <main className="bg min-h-screen bg-gray-50 py-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <div className="w-full px-2">
-        <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+        <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
           <div className="flex flex-col gap-3">
             <div className="flex flex-row gap-3">
               <div>
-                <label className="mb-1 block font-medium text-gray-700 text-xs">
+                <label className="mb-1 block font-medium text-gray-700 text-xs dark:text-gray-300">
                   Select a channel:
                   <select
                     name="channel"
                     value={channel}
                     onChange={(e) => setChannel(e.target.value)}
-                    className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:focus:border-blue-400"
                   >
                     {channels.map((channel) => (
                       <option key={channel} value={channel}>
@@ -249,26 +253,40 @@ function App() {
                 </label>
               </div>
               <div className="flex items-center">
-                <label className="mb-1 flex font-medium text-gray-700 text-xs">
-                  <input
-                    type="checkbox"
-                    name="allowPreReleases"
-                    className="ml-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
-                    checked={allowPreRelease}
-                    onChange={(e) => setAllowPreRelease(e.target.checked)}
-                  />
+                <label className="mb-1 flex items-center font-medium text-gray-700 text-xs dark:text-gray-300">
+                  <div className="relative ml-2">
+                    <input
+                      type="checkbox"
+                      name="allowPreReleases"
+                      className="peer h-4 w-4 appearance-none rounded border-2 border-gray-300 bg-white checked:border-blue-600 checked:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-blue-400 dark:checked:border-blue-500 dark:checked:bg-blue-500"
+                      checked={allowPreRelease}
+                      onChange={(e) => setAllowPreRelease(e.target.checked)}
+                    />
+                    <svg
+                      className="pointer-events-none absolute top-0 left-0 hidden h-4 w-4 text-white peer-checked:block"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <title>Checkmark</title>
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
                   <span className="ml-2">Show pre-releases</span>
                 </label>
               </div>
             </div>
             <div>
-              <label className="mb-1 block font-medium text-gray-700 text-xs">
+              <label className="mb-1 block font-medium text-gray-700 text-xs dark:text-gray-300">
                 Search for a module:
                 <input
                   type="search"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-blue-400"
                 />
               </label>
             </div>
@@ -284,7 +302,7 @@ function App() {
             />
           ))}
           {filteredRepos.length === 0 && (
-            <div className="text-gray-500">
+            <div className="text-gray-500 dark:text-gray-400">
               No modules found. Please clear search, change channel or upgrade
               JASP.
             </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -230,7 +230,7 @@ function App() {
   });
 
   return (
-    <main className="bg min-h-screen bg-gray-50 py-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <main className="min-h-screen bg-gray-50 py-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <div className="w-full px-2">
         <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
Uses prefers-color-scheme.
User can switch between dark/light mode in OS/browser to render web app.

<img width="657" height="564" alt="localhost_3000__a=Windows_x86-64 v=0 95 1 i=%7B%22jaspEquivalenceTTests%22%3A%227aad95f4_R-4-5-1%22%2C%22jaspTTests%22%3A%22a8098ba98_R-4-4-0%22%7D p=0" src="https://github.com/user-attachments/assets/f1b6adab-041e-4d98-acb0-abb31ef03a8a" />


To test dark mode in Chrome-based web browser you can open `Developer Tools` (F12), Run command (CTRL-SHIFT-P), search for `Emulate CSS prefers-color-schem: dark`.

