### PR TITLE
bugfix: don't break button text for Non-ASCII characters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,7 +254,7 @@ function ReleaseAction({
         <InstallButton asset={asset} translations={translations} />
       )}
       {allowPreRelease && latestPreRelease && (
-        <span className="whitespace-nowrap justify-center text-muted-foreground text-xs">
+        <span className="justify-center whitespace-nowrap text-muted-foreground text-xs">
           {pre_release.value}
         </span>
       )}


### PR DESCRIPTION
This fix some thing looks like:
<img width="471" height="175" alt="image" src="https://github.com/user-attachments/assets/42af0b80-cc5f-4514-b92c-25c4871973db" />