### PR TITLE
enh: make text color work with dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -843,7 +843,7 @@ function InfoButton({
       <div
         popover="auto"
         id="infoPopover"
-        className="relative m-8 mx-auto max-w-sm gap-2 self-center rounded-lg border border-border bg-card p-4"
+        className="relative m-8 mx-auto max-w-sm gap-2 self-center rounded-lg border border-border bg-card p-4 text-foreground"
       >
         <button
           popoverTarget="infoPopover"


### PR DESCRIPTION
infoPopover was not suitable with Dark theme in browser, let make text color work with it.